### PR TITLE
feat: add API with two endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "shop-angular-be",
+  "version": "1.0.0",
+  "description": "backend part for AWS course",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stg412/shop-angular-be.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/stg412/shop-angular-be/issues"
+  },
+  "homepage": "https://github.com/stg412/shop-angular-be#readme"
+}

--- a/product-service/.gitignore
+++ b/product-service/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/product-service/handler.js
+++ b/product-service/handler.js
@@ -1,0 +1,70 @@
+const products = [
+  {
+    id: "1",
+    title: "Book 1",
+    author: "Author 1",
+    price: 12.99,
+    count: 5,
+  },
+  {
+    id: "2",
+    title: "Book 2",
+    author: "Author 2",
+    price: 10.95,
+    count: 3,
+  },
+  {
+    id: "3",
+    title: "Book 3",
+    author: "Author 3",
+    price: 14.50,
+    count: 8,
+  },
+  {
+    id: "4",
+    title: "Book 4",
+    author: "Author 4",
+    price: 9.99,
+    count: 2,
+  },
+  {
+    id: "5",
+    title: "Book 5",
+    author: "Author 5",
+    price: 11.25,
+    count: 7,
+  },
+];
+
+module.exports.getProductsList = async (event) => {
+  return {
+    statusCode: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+    },
+    body: JSON.stringify(products),
+  };
+};
+
+module.exports.getProductsById = async (event) => {
+  const productId = event.pathParameters.productId; 
+  const product = products.find((p) => p.id === productId);
+
+  if (!product) {
+    return {
+      statusCode: 404, // Product not found
+      body: JSON.stringify({ message: "Product not found" }),
+    };
+  }
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+    },
+    body: JSON.stringify(product),
+  };
+}
+

--- a/product-service/serverless.yml
+++ b/product-service/serverless.yml
@@ -1,0 +1,129 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: product-service
+# app and org for use with dashboard.serverless.com
+#app: your-app-name
+#org: your-org-name
+
+# You can pin your service to only deploy with a specific Serverless version
+# Check out our docs for more details
+frameworkVersion: "3"
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  region: us-east-1
+
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
+
+# you can add statements to the Lambda function's IAM Role here
+#  iam:
+#    role:
+#      statements:
+#        - Effect: "Allow"
+#          Action:
+#            - "s3:ListBucket"
+#          Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#        - Effect: "Allow"
+#          Action:
+#            - "s3:PutObject"
+#          Resource:
+#            Fn::Join:
+#              - ""
+#              - - "arn:aws:s3:::"
+#                - "Ref" : "ServerlessDeploymentBucket"
+#                - "/*"
+
+# you can define service wide environment variables here
+#  environment:
+#    variable1: value1
+
+# you can add packaging information here
+#package:
+#  patterns:
+#    - '!exclude-me.js'
+#    - '!exclude-me-dir/**'
+#    - include-me.js
+#    - include-me-dir/**
+
+functions:
+  getProductsList:
+    handler: handler.getProductsList
+    events:
+      - http:
+          path: products
+          method: get
+          cors: true
+  getProductsById:
+    handler: handler.getProductsById
+    events:
+      - http:
+          path: products/{productId}
+          method: get
+          cors: true
+  # hello:
+  #   handler: handler.hello
+#    The following are a few example events you can configure
+#    NOTE: Please make sure to change your handler code to work with those events
+#    Check the event documentation for details
+#    events:
+#      - httpApi:
+#          path: /users/create
+#          method: get
+#      - websocket: $connect
+#      - s3: ${env:BUCKET}
+#      - schedule: rate(10 minutes)
+#      - sns: greeter-topic
+#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
+#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
+#      - iot:
+#          sql: "SELECT * FROM 'some_topic'"
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - "aws.ec2"
+#            detail-type:
+#              - "EC2 Instance State-change Notification"
+#            detail:
+#              state:
+#                - pending
+#      - cloudwatchLog: '/aws/lambda/hello'
+#      - cognitoUserPool:
+#          pool: MyUserPool
+#          trigger: PreSignUp
+#      - alb:
+#          listenerArn: arn:aws:elasticloadbalancing:us-east-1:XXXXXX:listener/app/my-load-balancer/50dc6c495c0c9188/
+#          priority: 1
+#          conditions:
+#            host: example.com
+#            path: /hello
+
+#    Define function environment variables here
+#    environment:
+#      variable2: value2
+
+# you can add CloudFormation resource templates here
+#resources:
+#  Resources:
+#    NewResource:
+#      Type: AWS::S3::Bucket
+#      Properties:
+#        BucketName: my-new-bucket
+#  Outputs:
+#     NewOutput:
+#       Description: "Description for the output"
+#       Value: "Some output value"


### PR DESCRIPTION
Product Service Serverless config contains configuration for 2 lambda functions - DONE
Service with two required endpoints - DONE
GET - https://zfhfqqao2e.execute-api.us-east-1.amazonaws.com/dev/products
GET - https://zfhfqqao2e.execute-api.us-east-1.amazonaws.com/dev/products/{productId}
Both endpoints WORKING. 

Link to cloudfront distribution 
https://d3joqbsltlv2xt.cloudfront.net/
Frontend application is integrated with Product Service (/products API) and products from Product Service are represented on Frontend - DONE

No additional scope

Product schema

{
  "id":"1",
  "title":"Book 1",
  "author":"Author 1",
  "price":12.99,
  "count":5
}

link to FE PR https://github.com/stg412/shop-angular-cloudfront/pull/2